### PR TITLE
Added caching for certain endpoints using Nancy

### DIFF
--- a/Caching/CacheProvider.cs
+++ b/Caching/CacheProvider.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using Nancy;
+
+namespace IzendaCustomBootstrapper.Caching
+{
+    public class CacheProvider
+    {
+        private static readonly Dictionary<string, int> endpointsToCacheWithLifetime = new Dictionary<string, int>
+        {
+            { "/api/tenant/activeTenants", 1000 },
+            { "/api/systemSetting/systemMode", 2100},
+            { "/api/systemSetting/systemModeSettings", 2100 },
+            { "/api/systemSetting/deploymentMode", 2100 },
+            { "/api/systemSetting/databaseSetup", 2100 },
+            { "/api/databaseSetup/SupportedDatabaseType", 2100 }
+        };
+
+        private static readonly Dictionary<string, Tuple<DateTime, Response, int>> cachedResponses = new Dictionary<string, Tuple<DateTime, Response, int>>();
+
+        public static Response CheckCache(NancyContext context)
+        {
+            Tuple<DateTime, Response, int> cacheEntry;
+
+            if (cachedResponses.TryGetValue(context.Request.Path, out cacheEntry))
+            {
+                if (cacheEntry.Item1.AddSeconds(cacheEntry.Item3) > DateTime.Now)
+                {
+                    return cacheEntry.Item2;
+                }
+            }
+
+            return null;
+        }
+
+        public static void SetCache(NancyContext context)
+        {
+            if (context.Response.StatusCode != HttpStatusCode.OK) { return; }
+
+            int cacheSeconds;
+            if (!endpointsToCacheWithLifetime.TryGetValue(context.Request.Path, out cacheSeconds)) { return; }
+
+            var cachedResponse = new CachedResponse(context.Response);
+
+            cachedResponses[context.Request.Path] = new Tuple<DateTime, Response, int>(DateTime.Now, cachedResponse, cacheSeconds);
+
+            context.Response = cachedResponse;
+        }
+    }
+}

--- a/Caching/CachedResponse.cs
+++ b/Caching/CachedResponse.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Nancy;
+
+namespace IzendaCustomBootstrapper.Caching
+{
+    /// <summary>
+    /// Wraps a regular response in a cached response
+    /// The cached response invokes the original response
+    /// </summary>
+    public class CachedResponse : Response
+    {
+        private readonly Response response;
+
+        public CachedResponse(Response response)
+        {
+            this.response = response;
+
+            this.ContentType = response.ContentType;
+            this.Headers = response.Headers;
+            this.StatusCode = response.StatusCode;
+            this.Contents = this.GetContents();
+        }
+
+        public override Task PreExecute(NancyContext context)
+        {
+            return this.response.PreExecute(context);
+        }
+
+        private Action<Stream> GetContents()
+        {
+            return stream =>
+            {
+                using (var memory = new MemoryStream())
+                {
+                    this.response.Contents.Invoke(memory);
+                    var contents = Encoding.ASCII.GetString(memory.ToArray());
+
+                    using (var writer = new StreamWriter(stream))
+                    {
+                        writer.Write(contents);
+                        writer.Flush();
+                    }
+                }
+            };
+        }
+    }
+}

--- a/CustomBootstrapper.cs
+++ b/CustomBootstrapper.cs
@@ -5,6 +5,7 @@ using Izenda.BI.Framework.Models.Paging;
 using Nancy;
 using Nancy.Bootstrapper;
 using Nancy.TinyIoc;
+using IzendaCustomBootstrapper.Caching;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
@@ -30,6 +31,9 @@ namespace IzendaCustomBootstrapper
 
         protected override void RequestStartup(TinyIoCContainer container, IPipelines pipelines, NancyContext context)
         {
+            pipelines.BeforeRequest += CacheProvider.CheckCache;
+            pipelines.AfterRequest += CacheProvider.SetCache;
+
             pipelines.AfterRequest.AddItemToEndOfPipeline(ctx =>
             {
                 // 'report/loadPartialFilterFieldData' endpoint
@@ -42,7 +46,7 @@ namespace IzendaCustomBootstrapper
                 LoadFilterFieldData(ctx);
 
                 // 'tenants/activeTenants' endpoint
-                LoadActiveTenantsData(ctx);
+                // LoadActiveTenantsData(ctx);
             });
 
             base.RequestStartup(container, pipelines, context);

--- a/IzendaCustomBootstrapper.csproj
+++ b/IzendaCustomBootstrapper.csproj
@@ -53,6 +53,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Caching\CachedResponse.cs" />
+    <Compile Include="Caching\CacheProvider.cs" />
     <Compile Include="CustomBootstrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
FB-3508: Used the Nancy Caching Sample (https://github.com/NancyFx/Nancy/tree/master/samples/Nancy.Demo.Caching) as a guide to set caching for certain endpoints. Endpoints are specified in a dictionary (Caching/CacheProvider.cs) along with its lifetime to be cached.  An in-memory dictionary is used at the default cache-provider, and is only used as a simple example.